### PR TITLE
Update validator guide for PoC4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "cSpell.words": [
+        "Blockxlabs",
+        "systemd"
+    ]
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 ## Why Polkadot?
 
-Polkadot is built to connect private/consortium chains, public/permissionless networks, oracles and future
+Polkadot is built to connect private/consortium chains, public/permission-less networks, oracles and future
 technological developments yet to be created in the Web3 ecosystem. It enables an internet where independent
 blockchains can exchange information and trust-free transactions via the Polkadot relay chain, with the key
 tenets of scalability, governance and interoperability.
@@ -19,11 +19,10 @@ of the messages between the chains. This interoperability also allows the additi
 a general environment for multiple state machines.
 
 Polkadot is a heterogeneous multi-chain technology. It consists of the relay chain, parachains, and bridges
-to other networks. The relay chain is responsible for acheiving consensus and transaction
+to other networks. The relay chain is responsible for achieving consensus and transaction
 delivery among parachains. Parachains are independent blockchains with their own state transitions
 that gather and process transactions while plugging in to the security of the relay chain. Bridges
-allow the Polkadot network to interoperate with other blockchains that may not be built
-to natively support it.
+allow the Polkadot network to make it interoperable with other blockchains not built to natively support it.
 
 ## Want to learn more?
 

--- a/docs/polkadot/learn/roadmap.md
+++ b/docs/polkadot/learn/roadmap.md
@@ -11,7 +11,7 @@ Polkadot is currently undergoing a series of proof-of-concept testnet releases a
 - PoC-7 (Release date TBD)
 - PoC-6 (Release date TBD)
 - PoC-5 (Release date TBD)
-- PoC-4 (Release date TBD) - _Interchain communications to be added_
+- PoC-4 (Release date 3 April 2019) - _Interchain communications to be added_
 - PoC-3 (Released 21 Dec 2018) - _GRANDPA finality gadget added,  Testnet: "Alexander"_ [Release Blog Post](https://medium.com/coinmonks/polkadot-hello-world-3-poc-3-on-substrate-is-here-c45d100f72e3)
 - BBQ-Birch testnet (Went live: 15 October 2018): _Added smart contract support._
 - PoC-2 (Released 29 Jul 2018) - _Support for parachains added; rewards and slashing added to PoS consensus algorithms.  Testnet: "Krumme Lanke". First automatic upgrade via governance._ [Release Blog Post](https://medium.com/polkadot-network/polkadot-poc-2-is-here-parachains-runtime-upgrades-and-libp2p-networking-7035bb141c25)

--- a/docs/polkadot/learn/security.md
+++ b/docs/polkadot/learn/security.md
@@ -2,13 +2,13 @@
 
 ## Pooled security
 
-Polkadot is designed to have pooled security on the relay chain and across parachains. This means that each parachain that is connected to the Polkadot network will have the same strong security guarentees of the relay chain. 
+Polkadot is designed to have pooled security on the relay chain and across parachains. This means that each parachain that is connected to the Polkadot network will have the same strong security guarantees of the relay chain. 
 
 ### Example
 
-Let's compare a non-shared security model like exists on current proof-of-work (PoW) chains to that of the shared security of Polkadot. Chains that are secured by sovereing PoW like Bitcoin, ZCash, Ethereum, and their derivatives all must maintain their own independent networks with its own hash power. Since mining is becoming more and more competitive, the amount of hashing power which is needed to mine a block on the big chains is becoming more as well. This means that smaller chains which cannot maintain the same amount of hash power on their networks could easily be attacked by a large mining cartel if it chooses to direct its power away from Bitcoin and toward a new and less secure chain.
+Let's compare a non-shared security model like exists on current proof-of-work (PoW) chains to that of the shared security of Polkadot. Chains that are secured by sovereign PoW like Bitcoin, ZCash, Ethereum, and their derivatives all must maintain their own independent networks with its own hash power. Since mining is becoming more and more competitive, the amount of hashing power which is needed to mine a block on the big chains is becoming more as well. This means that smaller chains which cannot maintain the same amount of hash power on their networks could easily be attacked by a large mining cartel if it chooses to direct its power away from Bitcoin and toward a new and less secure chain.
 
-On Polkadot, this disparity between chain security will not be present. When a parachain connects to Polkadot, the relay chain validator set become the secuerers of that chain's state transitions. The parachain will just need to run a few collator nodes to keep the validators informed with the latest state transitions and proofs. Validators will then check these for the parachains for which they are assigned. In this way, new parachains instantly benefit from the overall security of Polkadot even if they have just been launched.
+On Polkadot, this disparity between chain security will not be present. When a parachain connects to Polkadot, the relay chain validator set become the securers of that chain's state transitions. The parachain will just need to run a few collator nodes to keep the validators informed with the latest state transitions and proofs. Validators will then check these for the parachains for which they are assigned. In this way, new parachains instantly benefit from the overall security of Polkadot even if they have just been launched.
 
 ## How security is related to # of validators
 

--- a/docs/polkadot/learn/staking.md
+++ b/docs/polkadot/learn/staking.md
@@ -11,7 +11,7 @@ Stash & Controller accounts.
 
 **Stash:** The stash is responsible for holding an owner's funds used for staking (could be held in a cold wallet) and bonding DOTs to the controller. All bonded DOTs are locked. After unbonding, users must wait a certain amount of time in order to access the locked funds.
 
-**Controller:** It is actively reponsible for managing the account operations such as expressing an interest to switch between roles (validator, nominator, idle).
+**Controller:** It is actively responsible for managing the account operations such as expressing an interest to switch between roles (validator, nominator, idle).
 
 ## Operations
 

--- a/docs/polkadot/node/collator.md
+++ b/docs/polkadot/node/collator.md
@@ -2,7 +2,7 @@
 
 Collators maintain parachains by collecting parachain transactions from users and producing state transition proofs for validators.
 
-These participants will sit atop parachains and provide proofs to validators based on transactions from parachains. Collators maintain parachains by aggregating parachain transactions into parachain blocks and producing state transition proofs for validators based on those blocks. They also monitor the network and prove bad behaviour to validators. Collators maintain a “full-node” for a particular parachain; meaning they retain all necessary information to be able to author new blocks and execute transactions in much the same way as miners do on current PoW blockchains. Under normal circumstances, they will collate and execute transactions to create an unsealed block and provide it, together with a zero-knowledge proof, to one or more validators responsible for proposing a parachain block.
+These participants will sit atop parachains and provide proofs to validators based on transactions from parachains. Collators maintain parachains by aggregating parachain transactions into parachain blocks and producing state transition proofs for validators based on those blocks. They also monitor the network and prove bad behavior to validators. Collators maintain a “full-node” for a particular parachain; meaning they retain all necessary information to be able to author new blocks and execute transactions in much the same way as miners do on current PoW blockchains. Under normal circumstances, they will collate and execute transactions to create an unsealed block and provide it, together with a zero-knowledge proof, to one or more validators responsible for proposing a parachain block.
 
 ### Guides
 

--- a/docs/polkadot/node/council.md
+++ b/docs/polkadot/node/council.md
@@ -1,1 +1,0 @@
-# council

--- a/docs/polkadot/node/node-operator.md
+++ b/docs/polkadot/node/node-operator.md
@@ -7,7 +7,8 @@ These participants will play a crucial role in adding new blocks to the Relay Ch
 ## How to run a polkadot / validator node
 
 !!! info
-    _This tutorial works with current Alexander testnet. Once PoC-4 is released, contents will be updated as well._
+    _This tutorial works with current Alexander testnet and has been updated for PoC-4._
+
 To be a good validator, you should
 
 * Have certain amount of DOT stake (**Basic Requirement**)
@@ -22,21 +23,21 @@ You should **NOT** run a validator if you have DOTs, but you do not have enough 
 
 As a nominator, you can still get the rewards by nominating multiple validators. If you want to know more about nominator, please see [here](./nominator.md).
 
-For this tutorial, we use Ubuntu 18.04 and will be running on PoC-3 Alexander testnet. No matter what operating system you are using, setup should not be too much difference. There is a lot of [VPS](./node-operator.md#vps-list) choice out there, feel free to pick one you like.
-
+For this tutorial, we use Ubuntu 18.04 and will be running on PoC-4 Alexander testnet. No matter what operating system you are using, setup should not be too much difference. There is a lot of [VPS](./node-operator.md#vps-list) choice out there, feel free to pick one you like.
  
 !!! attention
     _Please make sure that you do **NOT** use this setup & configuration on mainnet. This guide simply walks you through step-by-step how to set up & run a validator node. If you would like to run a validator seriously when mainnet is live, you have to be REALLY careful on some areas like key management, DDOS protection and high availability._
 
 
-**Update to the latest version of polkadot**
+<!-- **Update to the latest version of polkadot** -->
 
-If you have installed polkadot already, you can use the following command to install the latest version and check your current version.
+<!-- Currently, the one-line installer will not work for PoC-4 -->
+<!-- If you have installed polkadot already, you can use the following command to install the latest version and check your current version.
 
 ```bash
-cargo install --git https://github.com/paritytech/polkadot.git --branch v0.3 polkadot --force
+cargo install --git https://github.com/paritytech/polkadot.git --branch v0.4 polkadot --force
 polkadot --version
-```
+``` -->
 
 **Install rust**
 
@@ -51,31 +52,43 @@ rustup update
 ```
 If you have installed rust already, run this command to check whether there is a new version available.
 
-**Install polkadot PoC-3 alexander**
+**Install polkadot PoC-4 Alexander**
 
-```bash
-cargo install --git https://github.com/paritytech/polkadot.git --branch v0.3 polkadot
+<!-- ```bash
+cargo install --git https://github.com/paritytech/polkadot.git --branch v0.4 polkadot
 ```
 
-This command will fetch & install the polkadot 0.3 version to your PATH.
+This command will fetch & install the polkadot 0.4 version to your PATH. -->
 
+Until support for the one-line installer is back up for PoC-4, you will need to build `polkadot` from source.
+
+```
+git clone https://github.com/paritytech/polkadot.git
+cd polkadot
+cargo clean
+git checkout v0.4
+./scripts/init.sh
+./scripts/build.sh
+cargo install --force --path ./ --branch v0.4.3
+```
+
+This may take a while depending on your hardware!
 
 **Synchronize chain data**
 
-After installed all related dependencies, you can start your polkadot node now. To synchronize the chain by executing the following command:
+After installing all related dependencies, you can start your polkadot node. Start to synchronize the chain by executing the following command:
 
 ```bash
-polkadot
+polkadot --chain alex
 ```
 
 It should take at least few hours.
-
 
 You can check the current highest block via [Telemetry](https://telemetry.polkadot.io/#/Alexander) or [PolkadotJS Block Explorer](https://polkadot.js.org/apps/#/explorer)
  
 **Create accounts**
 
-To be a validator, you also have to create two seperate accounts for managing your funds, namely `Stash` and `Controller`. If you want to know more about it, please see [here](../learn/staking.md#accounts). 
+To be a validator, you also have to create two separate accounts for managing your funds, namely `Stash` and `Controller`. If you want to know more about it, please see [here](../learn/staking.md#accounts). 
 
 
 ![create account](../../img/validator/polkadot-dashboard-create-account.jpg)
@@ -110,7 +123,7 @@ After the transaction has gone through successfully, you should see there is a `
 
 **Value boned** - how many DOTs you want to bond to this controller for staking
 
-**Payment destination** - decide your rewards where should it send
+**Payment destination** - where your rewards get sent
 
 If everything is inputted properly, click `Bond`.
 
@@ -213,8 +226,6 @@ You can tail the logs with `journalctl` like so:
 ```bash
 journalctl -f -u polkadot-validator
 ```
-
-
 
 ## Other References
 

--- a/docs/polkadot/node/nominator.md
+++ b/docs/polkadot/node/nominator.md
@@ -10,4 +10,4 @@ While your DOTs are staked by nominating a validator, they are 'locked'. You can
 
 ### Guides
 
-- [How to nominate](https://hackmd.io/5Vr3CvSPS0KS8JrJN_r58A#How-to-nominate) - Short guide on nominating for Alexander testnet v0.3.18+
+- [How to nominate](https://hackmd.io/5Vr3CvSPS0KS8JrJN_r58A#How-to-nominate) - Short guide on nominating for Alexander testnet v0.3.18


### PR DESCRIPTION
- updates instructions for running a validator for the latest `v0.4` branch
- some spelling fixes