### PR TITLE
Add links checker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  build:
+  tests:
     docker:
       - image: python:3.6-alpine3.9
     steps:
@@ -17,6 +17,23 @@ jobs:
             pip install -r requirements.txt
 
             mkdocs build --clean --site-dir _build/html --config-file ./mkdocs.yml
+      - run:
+          name: serve
+          background: true
+          command: |
+            source bin/activate
+
+            mkdocs serve
+
+      - run:
+          name: check links
+          command: |
+            pip install pylinkvalidator html5lib
+
+            sed -i -e 's/\(decode("ascii")\)/\1.replace(" ", "%20")/g' /usr/local/lib/python3.6/site-packages/pylinkvalidator/urlutil.py
+
+            pylinkvalidate.py --parser=html5lib -P http://localhost:8000
+
 
   spellCheck:
     docker:
@@ -31,9 +48,9 @@ jobs:
 
 workflows:
   version: 2
-  test_and_deploy:
+  build_and_tests:
     jobs:
-      - build:
+      - tests:
           filters:
             tags:
               only: /.*/

--- a/docs/polkadot/learn/index.md
+++ b/docs/polkadot/learn/index.md
@@ -23,7 +23,7 @@
 
 ## Resources
 
-- [Glossary](../glossary.md) - Definitions of domain specific terms used in Polkadot documentation.
+- [Glossary](../../glossary.md) - Definitions of domain specific terms used in Polkadot documentation.
 - [Implementations](./implementations.md) - List of implementations of the Polkadot protocol (who is building them and links to the source code).
 - [Links](./relevant-links.md) - Comprehensive list of external links.
 - [Roadmap](./roadmap.md) - The implementation roadmap of Polkadot.


### PR DESCRIPTION
Adds a link checker step to the CI build, the site is served locally and all the links are checked, if any of them is broken (even src fields for scripts) the build fails.

I've also taken the opportunity to fix the existing broken link.