### PR TITLE
Add This Week in Polkadot

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,5 +23,6 @@ If you're looking for an introduction on Polkadot please [see here](./polkadot/l
 ## Resources
 
 - [Community / Ecosystem](./community.md) - List of community rooms and channels to talk to others about Polkadot.
-- [Sample Applications](./polkadot/build/examples/) - Some sample applications that are built on or currently being built for Polkadot.
+- [News](./news.md) - Links to the hottest news about Polkadot, aggregated every week.
+- [Sample Applications](./polkadot/build/examples/) - Sample applications that are built on or currently being built for Polkadot.
 - [Contributing Guide](./contributing.md) - Rules for contributing to the wiki.

--- a/docs/news.md
+++ b/docs/news.md
@@ -2,6 +2,7 @@
 
 This Week in Polkadot is a weekly aggregation of the top news in the Polkadot space, maintained by Rory from W3F.
 
+- [This Week in Polkadot 10](https://www.reddit.com/r/dot/comments/bm5bmc/this_week_in_polkadot/) - May 8, 2019
 - [This Week in Polkadot 9](https://www.reddit.com/r/dot/comments/bj3mvo/this_week_in_polkadot/) - April 30, 2019
 - [This Week in Polkadot 8](https://www.reddit.com/r/dot/comments/bgkjhj/this_week_in_polkadot/) - April 23, 2019
 - [This Week in Polkadot 7](https://www.reddit.com/r/dot/comments/bdyg5w/this_week_in_polkadot/) - April 16, 2019

--- a/docs/news.md
+++ b/docs/news.md
@@ -1,0 +1,13 @@
+# This Week in Polkadot
+
+This Week in Polkadot is a weekly aggregation of the top news in the Polkadot space, maintained by Rory from W3F.
+
+- [This Week in Polkadot 9](https://www.reddit.com/r/dot/comments/bj3mvo/this_week_in_polkadot/) - April 30, 2019
+- [This Week in Polkadot 8](https://www.reddit.com/r/dot/comments/bgkjhj/this_week_in_polkadot/) - April 23, 2019
+- [This Week in Polkadot 7](https://www.reddit.com/r/dot/comments/bdyg5w/this_week_in_polkadot/) - April 16, 2019
+- [This Week in Polkadot 6](https://www.reddit.com/r/dot/comments/bayezl/this_week_in_polkadot/) - April 8, 2019 
+- [This Week in Polkadot 5](https://www.reddit.com/r/dot/comments/b87807/this_week_in_polkadot/) - April 1, 2019
+- [This Week in Polkadot 4](https://www.reddit.com/r/dot/comments/b532hl/this_week_in_polkadot/) - March 25, 2019 
+- [This Week in Polkadot 3](https://www.reddit.com/r/dot/comments/b1ja5z/this_week_in_rdot_march_15_2019/) - March 15, 2019
+- [This Week in Polkadot 2](https://www.reddit.com/r/dot/comments/av73tg/this_week_in_rdot_february_26_2019_week_2/) - February 26, 2019
+- [This Week in Polkadot](https://www.reddit.com/r/dot/comments/as39xj/this_week_in_rdot_february_18_2019/) - February 18, 2019

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
  - Other Languages:
    - Chinese: lang/chinese/index.md
    - Japanese: lang/japanese.md
+ - News: news.md
 
 # Configuration for the Material theme
 theme:


### PR DESCRIPTION
fixes #29 

@theroryshow posts an aggregation of news on Reddit every week titled "This Week in Polkadot." Instead of duplicating work by making our own news page, we can work with him to keep the list on the wiki up to date. 
