### PR TITLE
Update link for phragmen code

### DIFF
--- a/docs/polkadot/learn/phragmen.md
+++ b/docs/polkadot/learn/phragmen.md
@@ -28,5 +28,5 @@ The implementation of the Phragmen method can be found in the Substrate `srml-st
 
 - [W3F Research Page on Sequential Phragmen Method](https://research.web3.foundation/en/latest/polkadot/NPoS/4.%20Sequential%20Phragmén’s%20method/) - The formal adaptation of the Phragmen method as applied to Polkadot validators.
 - [Python Reference Implementations](https://github.com/w3f/consensus/tree/master/NPoS) - Implementations of Simple and Complicated Phragmen methods.
-- [Substrate Implementation](https://github.com/paritytech/substrate/blob/master/srml/staking/src/phragmen.rs) - Rust implementation used in the Substrate Runtime Module Library.
+- [Substrate Implementation](https://github.com/paritytech/substrate/blob/master/core/phragmen/src/lib.rs) - Rust implementation used in the Substrate Runtime Module Library.
 - [Phragmen's and Thiele's Election Methods](https://arxiv.org/pdf/1611.08826.pdf) - 95-page paper explaining Phragmen's election methods in detail.


### PR DESCRIPTION
Phragmen got moved to its own crate today, updating the link to the code in the wiki

Relevant PR: https://github.com/paritytech/substrate/pull/3498

